### PR TITLE
Allow DoctrineProvider to be autowired (Symfony 3.3+)

### DIFF
--- a/src/SitemapGenerator/Provider/DoctrineProvider.php
+++ b/src/SitemapGenerator/Provider/DoctrineProvider.php
@@ -2,7 +2,7 @@
 
 namespace SitemapGenerator\Provider;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\Routing\RouterInterface;
@@ -48,11 +48,11 @@ class DoctrineProvider extends AbstractProvider
     /**
      * Constructor
      *
-     * @param Entitymanager   $em      Doctrine entity manager.
-     * @param RouterInterface $router  The application router.
-     * @param array           $options The options (see the class comment).
+     * @param EntitymanagerInterface $em      Doctrine entity manager.
+     * @param RouterInterface        $router  The application router.
+     * @param array                  $options The options (see the class comment).
      */
-    public function __construct(EntityManager $em, RouterInterface $router, array $options)
+    public function __construct(EntityManagerInterface $em, RouterInterface $router, array $options)
     {
         parent::__construct($router, $options);
 


### PR DESCRIPTION
It allows us to use the autoconfigure/autowire features from Symfony 3.3+. Without it we get a 

> argument "$em" of method "SitemapGenerator\Provider\DoctrineProvider::__construct()" references class "Doctrine\ORM\EntityManager" but no such service exists. Try changing the type-hint to one of its par
  ents: interface "Doctrine\ORM\EntityManagerInterface", or interface "Doctrine\Common\Persistence\ObjectManager".

ex configuration:

```
    sitemap_xxx_provider_fr:
        class:      SitemapGenerator\Provider\DoctrineProvider
        tags: ['sitemap.provider']
        arguments:
            $options: '%providers_options_xxx_fr%'
```