### PR TITLE
Support for Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": "~7.1",
-        "symfony/property-access": "~3.0|^4.0",
+        "symfony/property-access": "^3.0|^4.0|^5.0",
         "nikic/iter": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",
-        "symfony/routing": "^3.0|^4.0",
+        "symfony/routing": "^3.0|^4.0|^5.0",
         "friendsofphp/php-cs-fixer": "^2.10",
         "kphoen/rusty": "dev-master"
     },

--- a/tests/Dumper/FileTest.php
+++ b/tests/Dumper/FileTest.php
@@ -11,10 +11,10 @@ class FileTest extends FileTestCase
         return new File($this->dummyFile());
     }
 
-    public function testDumper()
+    public function testDumper(): void
     {
         $this->dumper->dump('joe');
-        $this->assertTrue(file_exists($this->dummyFile()));
+        $this->assertFileExists($this->dummyFile());
 
         $this->assertSame('joe', file_get_contents($this->dummyFile()));
 
@@ -22,21 +22,20 @@ class FileTest extends FileTestCase
         $this->assertSame('joe-hell yeah!', file_get_contents($this->dummyFile()));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testAnExceptionIsThrownForNonWriteableFiles()
+    public function testAnExceptionIsThrownForNonWriteableFiles(): void
     {
+        $this->expectException(\RuntimeException::class);
+
         $dumper = new File($this->nonWriteableFile());
         $dumper->dump('foo');
     }
 
-    public function testCurrentFilenameIsAccessible()
+    public function testCurrentFilenameIsAccessible(): void
     {
         $this->assertSame($this->dummyFile(), $this->dumper->getFilename());
     }
 
-    public function testFilenameCanBeChanged()
+    public function testFilenameCanBeChanged(): void
     {
         $newDumper = $this->dumper->changeFile($this->otherDummyFile());
 

--- a/tests/Dumper/FileTestCase.php
+++ b/tests/Dumper/FileTestCase.php
@@ -14,7 +14,7 @@ abstract class FileTestCase extends TestCase
 
     abstract protected function createDumper();
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->file = sys_get_temp_dir() . '/dummy_file';
         $this->otherFile = sys_get_temp_dir() . '/other_file';
@@ -26,7 +26,7 @@ abstract class FileTestCase extends TestCase
         $this->dumper = $this->createDumper();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         file_exists($this->file) && unlink($this->file);
         file_exists($this->otherFile) && unlink($this->otherFile);

--- a/tests/Dumper/GzFileTest.php
+++ b/tests/Dumper/GzFileTest.php
@@ -11,12 +11,12 @@ class GzFileTest extends FileTestCase
         return new GzFile($this->dummyFile());
     }
 
-    public function testDumper()
+    public function testDumper(): void
     {
         $this->dumper->dump('joe');
         $this->dumper->dump('-hell yeah!');
 
-        $this->assertTrue(file_exists($this->dummyFile()));
+        $this->assertFileExists($this->dummyFile());
         unset($this->dumper); // force the dumper to close the file
 
         $this->assertSame('joe-hell yeah!', file_get_contents('compress.zlib://' . $this->dummyFile()));

--- a/tests/Dumper/MemoryTest.php
+++ b/tests/Dumper/MemoryTest.php
@@ -7,7 +7,7 @@ use SitemapGenerator\Dumper\Memory;
 
 class MemoryTest extends TestCase
 {
-    public function testDumper()
+    public function testDumper(): void
     {
         $dumper = new Memory();
         $this->assertSame('foo', $dumper->dump('foo'));

--- a/tests/Entity/SitemapIndexEntryTest.php
+++ b/tests/Entity/SitemapIndexEntryTest.php
@@ -7,15 +7,14 @@ use SitemapGenerator\Entity\SitemapIndexEntry;
 
 class SitemapIndexEntryTest extends TestCase
 {
-    /**
-     * @expectedException \DomainException
-     */
-    public function testLocMaxLength()
+    public function testLocMaxLength(): void
     {
+        $this->expectException(\DomainException::class);
+
         new SitemapIndexEntry('http://google.fr/?q=' . str_repeat('o', 2048));
     }
 
-    public function testConstructionWithASingleArgument()
+    public function testConstructionWithASingleArgument(): void
     {
         $entry = new SitemapIndexEntry('http://google.fr/');
 
@@ -23,7 +22,7 @@ class SitemapIndexEntryTest extends TestCase
         $this->assertNull($entry->getLastmod());
     }
 
-    public function testConstructionWithAllTheArguments()
+    public function testConstructionWithAllTheArguments(): void
     {
         $entry = new SitemapIndexEntry('http://google.fr/', \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2016-02-28 14:34:25', new \DateTimeZone('Europe/Paris')));
 

--- a/tests/Entity/UrlTest.php
+++ b/tests/Entity/UrlTest.php
@@ -10,29 +10,28 @@ use SitemapGenerator\Entity\Video;
 
 class UrlTest extends TestCase
 {
-    /**
-     * @expectedException \DomainException
-     */
-    public function testLocMaxLength()
+    public function testLocMaxLength(): void
     {
+        $this->expectException(\DomainException::class);
+
         new Url('http://google.fr/?q=' . str_repeat('o', 2048));
     }
 
     /**
      * @dataProvider invalidPriorityProvider
-     * @expectedException \DomainException
      */
-    public function testInvalidPriority($priority)
+    public function testInvalidPriority($priority): void
     {
+        $this->expectException(\DomainException::class);
+
         $url = new Url('http://www.google.fr/');
         $url->setPriority($priority);
     }
 
-    /**
-     * @expectedException \DomainException
-     */
-    public function testInvalidChangefreq()
+    public function testInvalidChangefreq(): void
     {
+        $this->expectException(\DomainException::class);
+
         $url = new Url('http://www.google.fr/');
         $url->setChangeFreq('foo');
     }
@@ -40,7 +39,7 @@ class UrlTest extends TestCase
     /**
      * @dataProvider changefreqProvider
      */
-    public function testChangefreq($changefreq)
+    public function testChangefreq($changefreq): void
     {
         $url = new Url('http://www.google.fr/');
         $url->setChangeFreq($changefreq);
@@ -51,7 +50,7 @@ class UrlTest extends TestCase
     /**
      * @dataProvider lastmodProvider
      */
-    public function testLastmodFormatting($lastmod, $changefreq, $expectedLastmod)
+    public function testLastmodFormatting($lastmod, $changefreq, $expectedLastmod): void
     {
         $url = new Url('http://www.google.fr/');
         $url->setLastmod($lastmod);
@@ -60,7 +59,7 @@ class UrlTest extends TestCase
         $this->assertSame($expectedLastmod, $url->getLastmod());
     }
 
-    public function testImages()
+    public function testImages(): void
     {
         $url = new Url('http://www.google.fr/');
         $image = new Image('https://www.google.fr/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png');
@@ -70,7 +69,7 @@ class UrlTest extends TestCase
         $this->assertSame([$image], $url->getImages());
     }
 
-    public function testVideos()
+    public function testVideos(): void
     {
         $url = new Url('http://www.google.fr/');
         $video = new Video('Title', 'Description.', 'https://thumbnail.loc/img.jpg');

--- a/tests/Entity/VideoTest.php
+++ b/tests/Entity/VideoTest.php
@@ -7,22 +7,20 @@ use SitemapGenerator\Entity\Video;
 
 class VideoTest extends TestCase
 {
-    /**
-     * @expectedException \DomainException
-     */
-    public function testTitleMaxLength()
+    public function testTitleMaxLength(): void
     {
+        $this->expectException(\DomainException::class);
+
         new Video(str_repeat('o', 100), 'Description.', 'https://thumbnail.loc/img.jpg');
         $this->assertTrue(true);
 
         new Video(str_repeat('o', 101), 'Description.', 'https://thumbnail.loc/img.jpg');
     }
 
-    /**
-     * @expectedException \DomainException
-     */
-    public function testDescriptionMaxLength()
+    public function testDescriptionMaxLength(): void
     {
+        $this->expectException(\DomainException::class);
+
         new Video('title', str_repeat('o', 2048), 'https://thumbnail.loc/img.jpg');
         $this->assertTrue(true);
 
@@ -31,10 +29,11 @@ class VideoTest extends TestCase
 
     /**
      * @dataProvider invalidDurationProvider
-     * @expectedException \DomainException
      */
-    public function testInvalidDuration($duration)
+    public function testInvalidDuration($duration): void
     {
+        $this->expectException(\DomainException::class);
+
         $video = new Video('title', 'Description', 'https://thumbnail.loc/img.jpg');
         $video->setDuration($duration);
     }
@@ -42,7 +41,7 @@ class VideoTest extends TestCase
     /**
      * @dataProvider dateProvider
      */
-    public function testExpirationDate($date, $expectedDate)
+    public function testExpirationDate($date, $expectedDate): void
     {
         $video = new Video('title', 'Description', 'https://thumbnail.loc/img.jpg');
         $video->setExpirationDate($date);
@@ -52,7 +51,7 @@ class VideoTest extends TestCase
     /**
      * @dataProvider dateProvider
      */
-    public function testPublicationDate($date, $expectedDate)
+    public function testPublicationDate($date, $expectedDate): void
     {
         $video = new Video('title', 'Description', 'https://thumbnail.loc/img.jpg');
         $video->setPublicationDate($date);
@@ -61,37 +60,35 @@ class VideoTest extends TestCase
 
     /**
      * @dataProvider invalidRatingProvider
-     * @expectedException \DomainException
      */
-    public function testInvalidRating($rating)
+    public function testInvalidRating($rating): void
     {
+        $this->expectException(\DomainException::class);
+
         $video = new Video('title', 'Description', 'https://thumbnail.loc/img.jpg');
         $video->setRating($rating);
     }
 
-    /**
-     * @expectedException \DomainException
-     */
-    public function testInvalidViewCount()
+    public function testInvalidViewCount(): void
     {
+        $this->expectException(\DomainException::class);
+
         $video = new Video('title', 'Description', 'https://thumbnail.loc/img.jpg');
         $video->setViewCount(-1);
     }
 
-    /**
-     * @expectedException \DomainException
-     */
-    public function testInvalidTagsCount()
+    public function testInvalidTagsCount(): void
     {
+        $this->expectException(\DomainException::class);
+
         $video = new Video('title', 'Description', 'https://thumbnail.loc/img.jpg');
         $video->setTags(array_pad([], 33, 'tag'));
     }
 
-    /**
-     * @expectedException \DomainException
-     */
-    public function testCategoryMaxLength()
+    public function testCategoryMaxLength(): void
     {
+        $this->expectException(\DomainException::class);
+
         $video = new Video('title', 'Description', 'https://thumbnail.loc/img.jpg');
         $video->setCategory(str_repeat('o', 256));
         $this->assertTrue(true);
@@ -99,29 +96,26 @@ class VideoTest extends TestCase
         $video->setCategory(str_repeat('o', 257));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInvalidRestriction()
+    public function testInvalidRestriction(): void
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $video = new Video('title', 'Description', 'https://thumbnail.loc/img.jpg');
         $video->setRestrictions(['fr', 'en'], 'foo');
     }
 
-    /**
-     * @expectedException \DomainException
-     */
-    public function testInvalidPlatform()
+    public function testInvalidPlatform(): void
     {
+        $this->expectException(\DomainException::class);
+
         $video = new Video('title', 'Description', 'https://thumbnail.loc/img.jpg');
         $video->setPlatforms([Video::PLATFORM_TV => Video::RESTRICTION_DENY, 'foo' => Video::RESTRICTION_DENY]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInvalidPlatformRelationship()
+    public function testInvalidPlatformRelationship(): void
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $video = new Video('title', 'Description', 'https://thumbnail.loc/img.jpg');
         $video->setPlatforms([Video::PLATFORM_TV => Video::RESTRICTION_DENY, Video::PLATFORM_MOBILE => 'foo']);
     }

--- a/tests/Formatter/RichXmlFormatterTest.php
+++ b/tests/Formatter/RichXmlFormatterTest.php
@@ -8,17 +8,17 @@ use SitemapGenerator\Formatter;
 
 class RichXmlFormatterTest extends XmlFormatterTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->formatter = new Formatter\RichXml();
     }
 
-    public function testSitemapStart()
+    public function testSitemapStart(): void
     {
         $this->assertSame('<?xml version="1.0" encoding="UTF-8"?>' . "\n" . '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">' . "\n", $this->formatter->getSitemapStart());
     }
 
-    public function testFormatRichUrl()
+    public function testFormatRichUrl(): void
     {
         $url = new RichUrl('http://www.google.fr');
         $url->setPriority(0.2);

--- a/tests/Formatter/SpacelessFormatterTest.php
+++ b/tests/Formatter/SpacelessFormatterTest.php
@@ -29,25 +29,25 @@ class TestableSitemapFormatter implements SitemapFormatter
 
 class SpacelessFormatterTest extends TestCase
 {
-    public function testSitemapStart()
+    public function testSitemapStart(): void
     {
         $formatter = new SpacelessFormatter(new TestableSitemapFormatter());
         $this->assertSame('joe', $formatter->getSitemapStart());
     }
 
-    public function testSitemapEnd()
+    public function testSitemapEnd(): void
     {
         $formatter = new SpacelessFormatter(new TestableSitemapFormatter());
         $this->assertSame('foo', $formatter->getSitemapEnd());
     }
 
-    public function testGetSitemapIndexStartWithSitemapFormatter()
+    public function testGetSitemapIndexStartWithSitemapFormatter(): void
     {
         $formatter = new SpacelessFormatter(new TestableSitemapFormatter());
         $this->assertSame('', $formatter->getSitemapIndexStart());
     }
 
-    public function testGetSitemapIndexStartWithSitemapIndexFormatter()
+    public function testGetSitemapIndexStartWithSitemapIndexFormatter(): void
     {
         $sitemapIndexFormatter = $this->createMock(SitemapIndexFormatter::class);
         $sitemapIndexFormatter
@@ -60,13 +60,13 @@ class SpacelessFormatterTest extends TestCase
         $this->assertSame('some value with spaces', $formatter->getSitemapIndexStart());
     }
 
-    public function testGetSitemapIndexEndWithSitemapFormatter()
+    public function testGetSitemapIndexEndWithSitemapFormatter(): void
     {
         $formatter = new SpacelessFormatter(new TestableSitemapFormatter());
         $this->assertSame('', $formatter->getSitemapIndexEnd());
     }
 
-    public function testGetSitemapIndexEndWithSitemapIndexFormatter()
+    public function testGetSitemapIndexEndWithSitemapIndexFormatter(): void
     {
         $sitemapIndexFormatter = $this->createMock(SitemapIndexFormatter::class);
         $sitemapIndexFormatter
@@ -79,7 +79,7 @@ class SpacelessFormatterTest extends TestCase
         $this->assertSame('some value with spaces', $formatter->getSitemapIndexEnd());
     }
 
-    public function testFormatSitemapIndexWithSitemapFormatter()
+    public function testFormatSitemapIndexWithSitemapFormatter(): void
     {
         $formatter = new SpacelessFormatter(new TestableSitemapFormatter());
         $entry = new SitemapIndexEntry('not relevant');
@@ -87,7 +87,7 @@ class SpacelessFormatterTest extends TestCase
         $this->assertSame('', $formatter->formatSitemapIndex($entry));
     }
 
-    public function testFormatSitemapIndexWithSitemapIndexFormatter()
+    public function testFormatSitemapIndexWithSitemapIndexFormatter(): void
     {
         $entry = new SitemapIndexEntry('not relevant');
 
@@ -103,7 +103,7 @@ class SpacelessFormatterTest extends TestCase
         $this->assertSame('some url', $formatter->formatSitemapIndex($entry));
     }
 
-    public function testFormatUrl()
+    public function testFormatUrl(): void
     {
         $formatter = new SpacelessFormatter(new TestableSitemapFormatter());
 

--- a/tests/Formatter/TextFormatterTest.php
+++ b/tests/Formatter/TextFormatterTest.php
@@ -8,19 +8,19 @@ use SitemapGenerator\Formatter;
 
 class TextFormatterTest extends TestCase
 {
-    public function testSitemapStart()
+    public function testSitemapStart(): void
     {
         $formatter = new Formatter\Text();
         $this->assertSame('', $formatter->getSitemapStart());
     }
 
-    public function testSitemapEnd()
+    public function testSitemapEnd(): void
     {
         $formatter = new Formatter\Text();
         $this->assertSame('', $formatter->getSitemapEnd());
     }
 
-    public function testFormatUrl()
+    public function testFormatUrl(): void
     {
         $formatter = new Formatter\Text();
 

--- a/tests/Formatter/XmlFormatterTest.php
+++ b/tests/Formatter/XmlFormatterTest.php
@@ -25,32 +25,32 @@ class XmlFormatterTest extends TestCase
      */
     protected $formatter;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->formatter = new Formatter\Xml();
     }
 
-    public function testSitemapStart()
+    public function testSitemapStart(): void
     {
         $this->assertSame('<?xml version="1.0" encoding="UTF-8"?>' . "\n" . '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">' . "\n", $this->formatter->getSitemapStart());
     }
 
-    public function testSitemapEnd()
+    public function testSitemapEnd(): void
     {
         $this->assertSame('</urlset>', $this->formatter->getSitemapEnd());
     }
 
-    public function testSitemapIndexStart()
+    public function testSitemapIndexStart(): void
     {
         $this->assertSame('<?xml version="1.0" encoding="UTF-8"?>' . "\n" . '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n", $this->formatter->getSitemapIndexStart());
     }
 
-    public function testSitemapIndexEnd()
+    public function testSitemapIndexEnd(): void
     {
         $this->assertSame('</sitemapindex>', $this->formatter->getSitemapIndexEnd());
     }
 
-    public function testFormatUrlOnlyLoc()
+    public function testFormatUrlOnlyLoc(): void
     {
         $url = new Url('http://www.google.fr');
 
@@ -59,7 +59,7 @@ class XmlFormatterTest extends TestCase
 "</url>\n", $this->formatter->formatUrl($url));
     }
 
-    public function testFormatUrl()
+    public function testFormatUrl(): void
     {
         $url = new Url('http://www.google.fr');
         $url->setPriority(0.2);
@@ -72,7 +72,7 @@ class XmlFormatterTest extends TestCase
 "</url>\n", $this->formatter->formatUrl($url));
     }
 
-    public function testFormatUrlWithLastMod()
+    public function testFormatUrlWithLastMod(): void
     {
         $lastmod = new \DateTimeImmutable('2016-02-28 14:51:22', new \DateTimeZone('Europe/Paris'));
         $url = new Url('http://www.google.fr');
@@ -84,7 +84,7 @@ class XmlFormatterTest extends TestCase
 "</url>\n", $this->formatter->formatUrl($url));
     }
 
-    public function testFormatUrlWithVideo()
+    public function testFormatUrlWithVideo(): void
     {
         $url = new Url('http://www.google.fr');
         $url->setPriority(0.2);
@@ -114,7 +114,7 @@ class XmlFormatterTest extends TestCase
 "</url>\n", $this->formatter->formatUrl($url));
     }
 
-    public function testFormatUrlWithImage()
+    public function testFormatUrlWithImage(): void
     {
         $url = new Url('http://www.google.fr');
         $url->setPriority(0.2);
@@ -136,7 +136,7 @@ class XmlFormatterTest extends TestCase
 "</url>\n", $this->formatter->formatUrl($url));
     }
 
-    public function testFormatUrlWithVideos()
+    public function testFormatUrlWithVideos(): void
     {
         $url = new Url('http://www.google.fr');
         $url->setPriority(0.2);
@@ -165,7 +165,7 @@ class XmlFormatterTest extends TestCase
 "</url>\n", $this->formatter->formatUrl($url));
     }
 
-    public function testFormatFullVideo()
+    public function testFormatFullVideo(): void
     {
         $formatter = new TestableXml();
 
@@ -214,7 +214,7 @@ class XmlFormatterTest extends TestCase
 "\t</video:video>\n", $formatter->testFormatVideo($video));
     }
 
-    public function testFormatUrlWithFullImage()
+    public function testFormatUrlWithFullImage(): void
     {
         $url = new Url('http://www.google.fr/?s=joe"');
         $url->setPriority(0.2);
@@ -242,7 +242,7 @@ class XmlFormatterTest extends TestCase
 "</url>\n", $this->formatter->formatUrl($url));
     }
 
-    public function testFormatSitemapIndexEntry()
+    public function testFormatSitemapIndexEntry(): void
     {
         $sitemapIndex = new SitemapIndexEntry('http://www.example.com/sitemap-1.xml', new \DateTime('2016-02-28 23:42:00', new \DateTimeZone('Europe/Paris')));
 
@@ -252,7 +252,7 @@ class XmlFormatterTest extends TestCase
 "</sitemap>\n", $this->formatter->formatSitemapIndex($sitemapIndex));
     }
 
-    public function testFormatSitemapIndexEntryNoLastMod()
+    public function testFormatSitemapIndexEntryNoLastMod(): void
     {
         $sitemapIndex = new SitemapIndexEntry('http://www.example.com/sitemap-1.xml');
 

--- a/tests/Provider/DefaultValuesTest.php
+++ b/tests/Provider/DefaultValuesTest.php
@@ -8,7 +8,7 @@ use SitemapGenerator\Provider\DefaultValues;
 
 class DefaultValuesTest extends TestCase
 {
-    public function testEmptyDefaultValuesCanBeCreated()
+    public function testEmptyDefaultValuesCanBeCreated(): void
     {
         $values = DefaultValues::none();
 
@@ -21,7 +21,7 @@ class DefaultValuesTest extends TestCase
         $this->assertNull($values->getChangeFreq());
     }
 
-    public function testDefaultValuesCanBeGiven()
+    public function testDefaultValuesCanBeGiven(): void
     {
         $priority = 0.4;
         $changeFreq = ChangeFrequency::ALWAYS;

--- a/tests/Provider/RouteTest.php
+++ b/tests/Provider/RouteTest.php
@@ -13,7 +13,7 @@ class RouteTest extends TestCase
     /**
      * @dataProvider newsDataProvider
      */
-    public function testPopulateWithNoResults(array $news, array $newsUrls)
+    public function testPopulateWithNoResults(array $news, array $newsUrls): void
     {
         $provider = $this->getNewsProvider($news);
 

--- a/tests/Routing/SymfonyUrlGeneratorTest.php
+++ b/tests/Routing/SymfonyUrlGeneratorTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SymfonyUrlGeneratorTest extends TestCase
 {
-    public function testGenerateDelegatesToTheUrlGenerator()
+    public function testGenerateDelegatesToTheUrlGenerator(): void
     {
         $route = 'route_name';
         $routeParameters = ['foo' => 'bar'];

--- a/tests/SitemapIndexTest.php
+++ b/tests/SitemapIndexTest.php
@@ -12,7 +12,7 @@ class SitemapIndexTest extends TestCase
 {
     const BASE_HOST = 'http://www.some-host.com/';
 
-    public function testProvidersCanBeRegistered()
+    public function testProvidersCanBeRegistered(): void
     {
         $sitemap = new SitemapIndex($this->getFileDumper(), $this->getFormatter(), self::BASE_HOST);
         $sitemap->addProvider(new \ArrayIterator([]));
@@ -20,7 +20,7 @@ class SitemapIndexTest extends TestCase
         $this->assertTrue(true, 'It did NOT fail \o/');
     }
 
-    public function testBuild()
+    public function testBuild(): void
     {
         $dumper = $this->getFileDumper();
         $formatter = $this->getFormatter();

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -13,7 +13,7 @@ use SitemapGenerator\SitemapFormatter;
 
 class SitemapTest extends TestCase
 {
-    public function testAddProvider()
+    public function testAddProvider(): void
     {
         $sitemap = new class($this->getDumper(), $this->getFormatter()) extends Sitemap {
             public function getProviders()
@@ -27,11 +27,11 @@ class SitemapTest extends TestCase
         $this->assertCount(1, $sitemap->getProviders());
     }
 
-    public function testRelativeUrlsAreKeptIntact()
+    public function testRelativeUrlsAreKeptIntact(): void
     {
         $dumper = new Dumper\Memory();
         $sitemap = new class($dumper, new Formatter\Text()) extends Sitemap {
-            public function testableAdd(Url $url)
+            public function testableAdd(Url $url): void
             {
                 $this->add($url, DefaultValues::none());
             }
@@ -44,7 +44,7 @@ class SitemapTest extends TestCase
         $this->assertSame('/search' . "\n", $dumper->getBuffer());
     }
 
-    public function testAddWithDefaultValues()
+    public function testAddWithDefaultValues(): void
     {
         $formatter = $this->getFormatter();
         $sitemap = new Sitemap($this->getDumper(), $formatter);
@@ -61,7 +61,7 @@ class SitemapTest extends TestCase
         $sitemap->build();
     }
 
-    public function testBuild()
+    public function testBuild(): void
     {
         $sitemap = new Sitemap(new Dumper\Memory(), new Formatter\Text());
         $sitemap->addProvider(new \ArrayIterator([new Url('http://www.google.fr/search')]));


### PR DESCRIPTION
- Add ^5.0 constraint to Symfony packages
- Update tests for PHPUnit 7.5+
    - Add null return types
    - Migrate exception expectations from annotations to method calls

Please let me know if you'd like anything added or changed, happy to collaborate.
