### PR TITLE
Clear the entity manager because there is a memory leak somewhere :)

### DIFF
--- a/src/SitemapGenerator/Provider/DoctrineProvider.php
+++ b/src/SitemapGenerator/Provider/DoctrineProvider.php
@@ -75,6 +75,8 @@ class DoctrineProvider extends AbstractProvider
 
             $this->em->detach($result[0]);
         }
+        
+        $this->em->clear();
     }
 
     protected function getQuery($entity, $method = null)


### PR DESCRIPTION
When using this bundle to dump a very very large set of data from doctrine (10 doctrine provider with 60,000 items) the memory keeps raising until we have no more memory left